### PR TITLE
Whitespace changes can be ignored

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "compile": "node ./node_modules/vscode/bin/compile -watch -p ./"
   },
   "dependencies": {
-    "git-blame": "^0.1.1",
+    "git-blame": "^1.1.0",
     "moment": "^2.10.6",
     "path": "^0.12.7",
     "typescript": "^1.6.2",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,16 @@
     "commands": [{
         "command": "extension.blame",
         "title": "Git Blame"
-    }]
+    }],
+    "configuration": {
+        "title": "Git Blame configuration",
+        "properties": {
+            "git-blame.ignore-whitespace-change":{
+                "type": "boolean",
+                "default": true,
+                "description" : "If set to true, git blame command will ignore any whitespace change applied to currently selected line"
+            }
+        }
+    }
   }
 }

--- a/src/gitblame.ts
+++ b/src/gitblame.ts
@@ -1,4 +1,4 @@
-
+import * as vscode from 'vscode';
 
 export class GitBlame {
     
@@ -39,7 +39,7 @@ export class GitBlame {
             
             self.gitBlameProcess(repo, {
                 file: fileName,
-                ignoreWhitespaces: true
+                ignoreWhitespaces: vscode.workspace.getConfiguration('git-blame').get<boolean>("ignore-whitespace-change", true)
             }).on('data', (type, data) => {
                 // outputs in Porcelain format.
                 if (type === 'line') {

--- a/src/gitblame.ts
+++ b/src/gitblame.ts
@@ -38,7 +38,8 @@ export class GitBlame {
             };
             
             self.gitBlameProcess(repo, {
-                file: fileName
+                file: fileName,
+                ignoreWhitespaces: true
             }).on('data', (type, data) => {
                 // outputs in Porcelain format.
                 if (type === 'line') {


### PR DESCRIPTION
Updated git-blame npm module to version 1.1.0 (implements possibility to ignore whitespace changes) and implemented this option into vscode-gitblame extension. 

Don't know if it is better to let user choose that he wants to ignore them or not, but I am not profficient with VSCode configuration schema, so it can be maybe implemented by someone else :)

EDIT: added configuration option, defaults on (true) ignore whitespace changes ;)